### PR TITLE
Version 4.4.0

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Move Artifacts
         run: |
           mkdir staging
+          mv target staging/parent
           mv api/target staging/api
           mv yaml/target staging/yaml
       - uses: actions/upload-artifact@v2.2.4

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -4,22 +4,25 @@ on: [ push, pull_request ]
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ '11', '16' ]
     steps:
       - uses: actions/checkout@v2.3.4
-      - name: Set up JDK 11
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v2.2.0
         with:
           distribution: 'adopt'
-          java-version: 11
+          java-version: ${{ matrix.java }}
       - uses: actions/cache@v2.1.6
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - name: Build with Maven
-        run: mvn -B package --file pom.xml
-      - name: Move built jars
+      - name: Build Project
+        run: mvn -B package --file pom.xml -Djava.version=${{ matrix.java }}
+      - name: Move Artifacts
         run: |
           mkdir staging
           mv api/target staging/api

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,5 +29,5 @@ jobs:
           mv yaml/target staging/yaml
       - uses: actions/upload-artifact@v2.2.4
         with:
-          name: Artifacts
+          name: Artifacts-Java-${{ matrix.java }}
           path: staging

--- a/.github/workflows/update-javadoc.yml
+++ b/.github/workflows/update-javadoc.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-      - name: Set up JDK 11
+      - name: Set up JDK 16
         uses: actions/setup-java@v2.2.0
         with:
           distribution: 'adopt'
-          java-version: 11
+          java-version: 16
       - uses: actions/cache@v2.1.6
         with:
           path: ~/.m2/repository
@@ -20,7 +20,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Build with Maven
-        run: mvn -B package -D java.version=11 --file pom.xml
+        run: mvn -B package -Djava.version=16 --file pom.xml
       - name: Deploy pages
         uses: peaceiris/actions-gh-pages@v3.8.0
         with:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Javadoc is [here](https://siroshun09.github.io/ConfigAPI/)
 <dependency>
     <groupId>com.github.siroshun09.configapi</groupId>
     <artifactId>configapi</artifactId>
-    <version>4.3.1</version>
+    <version>4.4.0-SNAPSHOT</version>
     <scope>compile</scope>
 </dependency>
 ```
@@ -32,7 +32,7 @@ Javadoc is [here](https://siroshun09.github.io/ConfigAPI/)
 <dependency>
     <groupId>com.github.siroshun09.configapi</groupId>
     <artifactId>configapi-yaml</artifactId>
-    <version>4.3.1</version>
+    <version>4.4.0-SNAPSHOT</version>
     <scope>compile</scope>
 </dependency>
 ```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Javadoc is [here](https://siroshun09.github.io/ConfigAPI/)
 <dependency>
     <groupId>com.github.siroshun09.configapi</groupId>
     <artifactId>configapi</artifactId>
-    <version>4.4.0-SNAPSHOT</version>
+    <version>4.4.0</version>
     <scope>compile</scope>
 </dependency>
 ```
@@ -32,7 +32,7 @@ Javadoc is [here](https://siroshun09.github.io/ConfigAPI/)
 <dependency>
     <groupId>com.github.siroshun09.configapi</groupId>
     <artifactId>configapi-yaml</artifactId>
-    <version>4.4.0-SNAPSHOT</version>
+    <version>4.4.0</version>
     <scope>compile</scope>
 </dependency>
 ```

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.github.siroshun09.configapi</groupId>
         <artifactId>parent</artifactId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>4.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.github.siroshun09.configapi</groupId>
         <artifactId>parent</artifactId>
-        <version>4.3.1</version>
+        <version>4.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/api/src/main/java/com/github/siroshun09/configapi/api/AbstractConfiguration.java
+++ b/api/src/main/java/com/github/siroshun09/configapi/api/AbstractConfiguration.java
@@ -180,7 +180,12 @@ public abstract class AbstractConfiguration implements Configuration {
     @Override
     public @NotNull String getString(@NotNull String path, @NotNull String def) {
         var value = get(path);
-        return value instanceof String ? (String) value : def;
+
+        if (value != null) {
+            return value instanceof String ? (String) value : value.toString();
+        } else {
+            return Objects.requireNonNull(def);
+        }
     }
 
     @Override

--- a/api/src/main/java/com/github/siroshun09/configapi/api/AbstractConfiguration.java
+++ b/api/src/main/java/com/github/siroshun09/configapi/api/AbstractConfiguration.java
@@ -38,7 +38,7 @@ public abstract class AbstractConfiguration implements Configuration {
     @Override
     public @NotNull Object get(@NotNull String path, @NotNull Object def) {
         var value = get(path);
-        return value != null ? value : Objects.requireNonNull(path);
+        return value != null ? value : Objects.requireNonNull(def);
     }
 
     @Override

--- a/api/src/main/java/com/github/siroshun09/configapi/api/AbstractConfiguration.java
+++ b/api/src/main/java/com/github/siroshun09/configapi/api/AbstractConfiguration.java
@@ -314,6 +314,7 @@ public abstract class AbstractConfiguration implements Configuration {
 
         if (list != null) {
             return list.stream()
+                    .filter(Objects::nonNull)
                     .map(object -> object instanceof String ? (String) object : object.toString())
                     .collect(Collectors.toUnmodifiableList());
         } else {

--- a/api/src/main/java/com/github/siroshun09/configapi/api/AbstractConfiguration.java
+++ b/api/src/main/java/com/github/siroshun09/configapi/api/AbstractConfiguration.java
@@ -71,7 +71,7 @@ public abstract class AbstractConfiguration implements Configuration {
     @Override
     public @NotNull @Unmodifiable List<?> getList(@NotNull String path, @NotNull List<?> def) {
         var value = get(path);
-        return value instanceof List<?> ? (List<?>) value : def;
+        return value instanceof List<?> ? (List<?>) value : Objects.requireNonNull(def);
     }
 
     @Override

--- a/api/src/main/java/com/github/siroshun09/configapi/api/Configuration.java
+++ b/api/src/main/java/com/github/siroshun09/configapi/api/Configuration.java
@@ -348,7 +348,7 @@ public interface Configuration {
     /**
      * Gets the string of the specified path.
      * <p>
-     * If the string could not be obtained, this method returns 0.
+     * If the string could not be obtained, this method returns empty string.
      *
      * @param path the path to get the string
      * @return the string

--- a/api/src/main/java/com/github/siroshun09/configapi/api/Configuration.java
+++ b/api/src/main/java/com/github/siroshun09/configapi/api/Configuration.java
@@ -120,7 +120,7 @@ public interface Configuration {
 
     /**
      * Gets the list of root keys included in this {@link Configuration}.
-     *
+     * <p>
      * This method may not return to the correct order depending on the implementation.
      *
      * @return list of root keys
@@ -369,6 +369,9 @@ public interface Configuration {
      * <p>
      * If the boolean list could not be obtained,
      * this method returns {@link Collections#emptyList()}.
+     * <p>
+     * If the list that obtained from {@link Configuration#getList(String)}
+     * contains an object that cannot be converted to a boolean, it will be excluded.
      *
      * @param path the path to get the boolean list
      * @return the boolean list
@@ -377,6 +380,9 @@ public interface Configuration {
 
     /**
      * Gets the boolean list of the specified path.
+     * <p>
+     * If the list that obtained from {@link Configuration#getList(String)}
+     * contains an object that cannot be converted to a boolean, it will be excluded.
      *
      * @param path the path to get the boolean list
      * @param def  the default boolean list to return if the boolean list could not be obtained
@@ -389,6 +395,12 @@ public interface Configuration {
      * <p>
      * If the byte list could not be obtained,
      * this method returns {@link Collections#emptyList()}.
+     * <p>
+     * If the list that obtained from {@link Configuration#getList(String)}
+     * contains an object that cannot be converted to a number, it will be excluded.
+     * <p>
+     * If the list contains a number that is outside the byte range,
+     * it will be converted to a byte using {@link Number#byteValue()}.
      *
      * @param path the path to get the byte list
      * @return the byte list
@@ -397,6 +409,12 @@ public interface Configuration {
 
     /**
      * Gets the byte list of the specified path.
+     * <p>
+     * If the list that obtained from {@link Configuration#getList(String)}
+     * contains an object that cannot be converted to a number, it will be excluded.
+     * <p>
+     * If the list contains a number that is outside the byte range,
+     * it will be converted to a byte using {@link Number#byteValue()}.
      *
      * @param path the path to get the byte list
      * @param def  the default byte list to return if the byte list could not be obtained
@@ -409,6 +427,12 @@ public interface Configuration {
      * <p>
      * If the double list could not be obtained,
      * this method returns {@link Collections#emptyList()}.
+     * <p>
+     * If the list that obtained from {@link Configuration#getList(String)}
+     * contains an object that cannot be converted to a number, it will be excluded.
+     * <p>
+     * If the list contains a number that is outside the double range,
+     * it will be converted to a byte using {@link Number#doubleValue()}.
      *
      * @param path the path to get the double list
      * @return the double list
@@ -417,6 +441,12 @@ public interface Configuration {
 
     /**
      * Gets the double list of the specified path.
+     * <p>
+     * If the list that obtained from {@link Configuration#getList(String)}
+     * contains an object that cannot be converted to a number, it will be excluded.
+     * <p>
+     * If the list contains a number that is outside the double range,
+     * it will be converted to a byte using {@link Number#doubleValue()}.
      *
      * @param path the path to get the double list
      * @param def  the default double list to return if the double list could not be obtained
@@ -429,6 +459,12 @@ public interface Configuration {
      * <p>
      * If the float list could not be obtained,
      * this method returns {@link Collections#emptyList()}.
+     * <p>
+     * If the list that obtained from {@link Configuration#getList(String)}
+     * contains an object that cannot be converted to a number, it will be excluded.
+     * <p>
+     * If the list contains a number that is outside the float range,
+     * it will be converted to a byte using {@link Number#floatValue()}.
      *
      * @param path the path to get the float list
      * @return the float list
@@ -437,6 +473,12 @@ public interface Configuration {
 
     /**
      * Gets the float list of the specified path.
+     * <p>
+     * If the list that obtained from {@link Configuration#getList(String)}
+     * contains an object that cannot be converted to a number, it will be excluded.
+     * <p>
+     * If the list contains a number that is outside the float range,
+     * it will be converted to a byte using {@link Number#floatValue()}.
      *
      * @param path the path to get the float list
      * @param def  the default float list to return if the float list could not be obtained
@@ -449,6 +491,12 @@ public interface Configuration {
      * <p>
      * If the integer list could not be obtained,
      * this method returns {@link Collections#emptyList()}.
+     * <p>
+     * If the list that obtained from {@link Configuration#getList(String)}
+     * contains an object that cannot be converted to a number, it will be excluded.
+     * <p>
+     * If the list contains a number that is outside the int range,
+     * it will be converted to a byte using {@link Number#intValue()}.
      *
      * @param path the path to get the integer list
      * @return the integer list
@@ -457,6 +505,12 @@ public interface Configuration {
 
     /**
      * Gets the integer list of the specified path.
+     * <p>
+     * If the list that obtained from {@link Configuration#getList(String)}
+     * contains an object that cannot be converted to a number, it will be excluded.
+     * <p>
+     * If the list contains a number that is outside the int range,
+     * it will be converted to a byte using {@link Number#intValue()}.
      *
      * @param path the path to get the integer list
      * @param def  the default integer list to return if the integer list could not be obtained
@@ -469,6 +523,12 @@ public interface Configuration {
      * <p>
      * If the long list could not be obtained,
      * this method returns {@link Collections#emptyList()}.
+     * <p>
+     * If the list that obtained from {@link Configuration#getList(String)}
+     * contains an object that cannot be converted to a number, it will be excluded.
+     * <p>
+     * If the list contains a number that is outside the long range,
+     * it will be converted to a byte using {@link Number#longValue()}.
      *
      * @param path the path to get the long list
      * @return the long list
@@ -477,6 +537,12 @@ public interface Configuration {
 
     /**
      * Gets the long list of the specified path.
+     * <p>
+     * If the list that obtained from {@link Configuration#getList(String)}
+     * contains an object that cannot be converted to a number, it will be excluded.
+     * <p>
+     * If the list contains a number that is outside the long range,
+     * it will be converted to a byte using {@link Number#longValue()}.
      *
      * @param path the path to get the long list
      * @param def  the default long list to return if the long list could not be obtained
@@ -489,6 +555,12 @@ public interface Configuration {
      * <p>
      * If the short list could not be obtained,
      * this method returns {@link Collections#emptyList()}.
+     * <p>
+     * If the list that obtained from {@link Configuration#getList(String)}
+     * contains an object that cannot be converted to a number, it will be excluded.
+     * <p>
+     * If the list contains a number that is outside the short range,
+     * it will be converted to a byte using {@link Number#shortValue()}.
      *
      * @param path the path to get the short list
      * @return the short list
@@ -497,6 +569,12 @@ public interface Configuration {
 
     /**
      * Gets the short list of the specified path.
+     * <p>
+     * If the list that obtained from {@link Configuration#getList(String)}
+     * contains an object that cannot be converted to a number, it will be excluded.
+     * <p>
+     * If the list contains a number that is outside the short range,
+     * it will be converted to a byte using {@link Number#shortValue()}.
      *
      * @param path the path to get the short list
      * @param def  the default short list to return if the short list could not be obtained
@@ -509,6 +587,10 @@ public interface Configuration {
      * <p>
      * If the string list could not be obtained,
      * this method returns {@link Collections#emptyList()}.
+     * <p>
+     * If the list that obtained from {@link Configuration#getList(String)} contains non-string object,
+     * it will be converted to a string based on {@link Object#toString()}
+     * or the <code>toString</code> implementation of that object.
      *
      * @param path the path to get the string list
      * @return the string list
@@ -517,6 +599,10 @@ public interface Configuration {
 
     /**
      * Gets the string list of the specified path.
+     * <p>
+     * If the list that obtained from {@link Configuration#getList(String)} contains non-string object,
+     * it will be converted to a string based on {@link Object#toString()}
+     * or the <code>toString</code> implementation of that object.
      *
      * @param path the path to get the string list
      * @param def  the default string list to return if the string list could not be obtained

--- a/api/src/main/java/com/github/siroshun09/configapi/api/Configuration.java
+++ b/api/src/main/java/com/github/siroshun09/configapi/api/Configuration.java
@@ -119,15 +119,6 @@ public interface Configuration {
     <T> void set(@NotNull String path, @NotNull T value, @NotNull Serializer<T, ?> serializer);
 
     /**
-     * Gets the set of root paths included in this {@link Configuration}.
-     *
-     * @return set of root paths
-     * @deprecated use {@link Configuration#getKeyList()}
-     */
-    @Deprecated(since = "4.3.0", forRemoval = true)
-    @NotNull @Unmodifiable Set<String> getPaths();
-
-    /**
      * Gets the list of root keys included in this {@link Configuration}.
      *
      * This method may not return to the correct order depending on the implementation.

--- a/api/src/main/java/com/github/siroshun09/configapi/api/MappedConfiguration.java
+++ b/api/src/main/java/com/github/siroshun09/configapi/api/MappedConfiguration.java
@@ -172,13 +172,6 @@ public class MappedConfiguration extends AbstractConfiguration {
     }
 
     @Override
-    public @NotNull @Unmodifiable Set<String> getPaths() {
-        return map.keySet().stream()
-                .map(object -> object instanceof String ? (String) object : object.toString())
-                .collect(Collectors.toUnmodifiableSet());
-    }
-
-    @Override
     public @NotNull @Unmodifiable List<String> getKeyList() {
         return map.keySet().stream()
                 .map(object -> object instanceof String ? (String) object : object.toString())

--- a/api/src/main/java/com/github/siroshun09/configapi/api/file/PropertiesConfiguration.java
+++ b/api/src/main/java/com/github/siroshun09/configapi/api/file/PropertiesConfiguration.java
@@ -80,14 +80,6 @@ public class PropertiesConfiguration extends AbstractFileConfiguration {
     }
 
     @Override
-    public @NotNull @Unmodifiable Set<String> getPaths() {
-        return properties.keySet()
-                .stream()
-                .map(object -> object instanceof String ? (String) object : object.toString())
-                .collect(Collectors.toUnmodifiableSet());
-    }
-
-    @Override
     public @NotNull @Unmodifiable List<String> getKeyList() {
         return properties.keySet()
                 .stream()

--- a/api/src/main/java/com/github/siroshun09/configapi/api/serializer/ConfigurationSerializer.java
+++ b/api/src/main/java/com/github/siroshun09/configapi/api/serializer/ConfigurationSerializer.java
@@ -50,7 +50,7 @@ public interface ConfigurationSerializer<T> extends Serializer<T, Configuration>
      * Deserializes {@link Configuration}
      *
      * @param config the config to deserialize
-     * @return the deserialized value or {@code null} if could not deserialize
+     * @return the deserialized value or {@code null} if configuration could not be deserialized
      */
     @Nullable T deserializeConfiguration(@NotNull Configuration config);
 }

--- a/api/src/main/java/com/github/siroshun09/configapi/api/serializer/StringSerializer.java
+++ b/api/src/main/java/com/github/siroshun09/configapi/api/serializer/StringSerializer.java
@@ -39,7 +39,7 @@ public interface StringSerializer<T> extends Serializer<T, String> {
      * Deserializes the {@link String}.
      *
      * @param source the string to deserialize
-     * @return the deserialized value or {@code null} if could not deserialize
+     * @return the deserialized value or {@code null} if string could not be deserialized
      */
     @Nullable T deserializeString(@NotNull String source);
 }

--- a/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
+++ b/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
@@ -230,6 +230,27 @@ public class AbstractConfigurationTest {
         Assertions.assertSame(def, config.getBooleanList("empty", def));
     }
 
+    @Test
+    void testGettingByteList() {
+        var list = List.of(new Object(), 5, -5, 300, true, "test");
+
+        var config = newConfiguration();
+        config.set("test", list);
+
+        var actual = config.getByteList("test");
+
+        Assertions.assertEquals(3, config.getByteList("test").size());
+
+        for (Object object : actual) {
+            Assertions.assertEquals(Byte.class, object.getClass());
+        }
+
+        Assertions.assertSame(Collections.emptyList(), config.getByteList("empty"));
+
+        var def = List.of((byte) 5, (byte) -5);
+        Assertions.assertSame(def, config.getByteList("empty", def));
+    }
+
     @SuppressWarnings("ConstantConditions")
     @Test
     void testIllegalArguments() {

--- a/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
+++ b/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
@@ -47,6 +47,18 @@ public class AbstractConfigurationTest {
         Assertions.assertSame(Collections.emptyList(), config.getList("test"));
     }
 
+    @Test
+    void testGettingBoolean() {
+        var config = newConfiguration();
+
+        config.set("test", true);
+        Assertions.assertTrue(config.getBoolean("test"));
+
+        config.set("test-string", "true");
+        Assertions.assertFalse(config.getBoolean("test-string"));
+        Assertions.assertTrue(config.getBoolean("test-string", true));
+    }
+
     @Contract(" -> new")
     private static @NotNull Configuration newConfiguration() {
         return MappedConfiguration.create();

--- a/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
+++ b/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
@@ -282,7 +282,7 @@ public class AbstractConfigurationTest {
 
         var actual = config.getFloatList("test");
 
-        Assertions.assertEquals(4, actual.size());
+        Assertions.assertEquals(3, actual.size());
 
         for (Object object : actual) {
             Assertions.assertEquals(Float.class, object.getClass());

--- a/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
+++ b/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
@@ -80,6 +80,26 @@ public class AbstractConfigurationTest {
         Assertions.assertEquals(Byte.MAX_VALUE, config.getByte("test-max"));
     }
 
+    @Test
+    void testGettingDouble() {
+        var config = newConfiguration();
+
+        config.set("test-1", 5);
+        config.set("test-2", -5);
+
+        Assertions.assertEquals(5, config.getDouble("test-1"));
+        Assertions.assertEquals(-5, config.getDouble("test-2"));
+
+        config.set("test-min", Double.MIN_VALUE);
+        config.set("test-max", Double.MAX_VALUE);
+
+        Assertions.assertEquals(Double.MIN_VALUE, config.getDouble("test-min"));
+        Assertions.assertEquals(Double.MAX_VALUE, config.getDouble("test-max"));
+
+        Assertions.assertEquals(0, config.getDouble("empty"));
+        Assertions.assertEquals(100, config.getDouble("empty", 100));
+    }
+
     @SuppressWarnings("ConstantConditions")
     @Test
     void testIllegalArguments() {
@@ -94,5 +114,4 @@ public class AbstractConfigurationTest {
     private static @NotNull Configuration newConfiguration() {
         return MappedConfiguration.create();
     }
-
 }

--- a/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
+++ b/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
@@ -356,6 +356,43 @@ public class AbstractConfigurationTest {
         Assertions.assertSame(def, config.getShortList("empty", def));
     }
 
+    @Test
+    void testGettingStringList() {
+        var list = List.of(new Object(), "test", "", 100, true);
+
+        var config = newConfiguration();
+        config.set("test-1", list);
+
+        var actual = config.getStringList("test-1");
+
+        Assertions.assertEquals(5, config.getStringList("test-1").size());
+
+        for (Object object : actual) {
+            Assertions.assertEquals(String.class, object.getClass());
+        }
+
+        var includeNull = new ArrayList<>();
+        includeNull.add("test");
+        includeNull.add(null);
+        includeNull.add(100);
+        includeNull.add(true);
+
+        config.set("test-2", includeNull);
+
+        var actual2 = config.getStringList("test-2");
+
+        Assertions.assertEquals(3, config.getStringList("test-2").size());
+
+        for (Object object : actual2) {
+            Assertions.assertEquals(String.class, object.getClass());
+        }
+
+        Assertions.assertSame(Collections.emptyList(), config.getShortList("empty"));
+
+        var def = List.of("test", "test");
+        Assertions.assertSame(def, config.getStringList("empty", def));
+    }
+
     @SuppressWarnings("ConstantConditions")
     @Test
     void testIllegalArguments() {

--- a/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
+++ b/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
@@ -335,6 +335,27 @@ public class AbstractConfigurationTest {
         Assertions.assertSame(def, config.getLongList("empty", def));
     }
 
+    @Test
+    void testGettingShortList() {
+        var list = List.of(new Object(), 5, -5, Long.MAX_VALUE, 5.5, true, "test");
+
+        var config = newConfiguration();
+        config.set("test", list);
+
+        var actual = config.getShortList("test");
+
+        Assertions.assertEquals(4, config.getShortList("test").size());
+
+        for (Object object : actual) {
+            Assertions.assertEquals(Short.class, object.getClass());
+        }
+
+        Assertions.assertSame(Collections.emptyList(), config.getShortList("empty"));
+
+        var def = List.of((short) 5, (short) -5);
+        Assertions.assertSame(def, config.getShortList("empty", def));
+    }
+
     @SuppressWarnings("ConstantConditions")
     @Test
     void testIllegalArguments() {

--- a/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
+++ b/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
@@ -149,6 +149,29 @@ public class AbstractConfigurationTest {
         Assertions.assertEquals(100, config.getInteger("empty", 100));
     }
 
+    @Test
+    void testGettingLong() {
+        var config = newConfiguration();
+
+        config.set("test-1", 5);
+        config.set("test-2", -5);
+
+        Assertions.assertEquals(5, config.getLong("test-1"));
+        Assertions.assertEquals(-5, config.getLong("test-2"));
+
+        config.set("test-3", Double.MAX_VALUE);
+        Assertions.assertNotEquals(Double.MAX_VALUE, config.getLong("test-3"));
+
+        config.set("test-min", Long.MIN_VALUE);
+        config.set("test-max", Long.MAX_VALUE);
+
+        Assertions.assertEquals(Long.MIN_VALUE, config.getLong("test-min"));
+        Assertions.assertEquals(Long.MAX_VALUE, config.getLong("test-max"));
+
+        Assertions.assertEquals(0, config.getLong("empty"));
+        Assertions.assertEquals(100, config.getLong("empty", 100));
+    }
+
     @SuppressWarnings("ConstantConditions")
     @Test
     void testIllegalArguments() {

--- a/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
+++ b/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
@@ -103,6 +103,29 @@ public class AbstractConfigurationTest {
         Assertions.assertEquals(100, config.getDouble("empty", 100));
     }
 
+    @Test
+    void testGettingFloat() {
+        var config = newConfiguration();
+
+        config.set("test-1", 5);
+        config.set("test-2", -5);
+
+        Assertions.assertEquals(5, config.getFloat("test-1"));
+        Assertions.assertEquals(-5, config.getFloat("test-2"));
+
+        config.set("test-3", Double.MAX_VALUE);
+        Assertions.assertNotEquals(Double.MAX_VALUE, config.getFloat("test-3"));
+
+        config.set("test-min", Float.MIN_VALUE);
+        config.set("test-max", Float.MAX_VALUE);
+
+        Assertions.assertEquals(Float.MIN_VALUE, config.getFloat("test-min"));
+        Assertions.assertEquals(Float.MAX_VALUE, config.getFloat("test-max"));
+
+        Assertions.assertEquals(0, config.getFloat("empty"));
+        Assertions.assertEquals(100, config.getFloat("empty", 100));
+    }
+
     @SuppressWarnings("ConstantConditions")
     @Test
     void testIllegalArguments() {

--- a/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
+++ b/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
@@ -218,7 +218,7 @@ public class AbstractConfigurationTest {
 
         var actual = config.getBooleanList("test");
 
-        Assertions.assertEquals(4, config.getBooleanList("test").size());
+        Assertions.assertEquals(4, actual.size());
 
         for (Object object : actual) {
             Assertions.assertEquals(Boolean.class, object.getClass());
@@ -239,7 +239,7 @@ public class AbstractConfigurationTest {
 
         var actual = config.getByteList("test");
 
-        Assertions.assertEquals(3, config.getByteList("test").size());
+        Assertions.assertEquals(3, actual.size());
 
         for (Object object : actual) {
             Assertions.assertEquals(Byte.class, object.getClass());
@@ -260,7 +260,7 @@ public class AbstractConfigurationTest {
 
         var actual = config.getDoubleList("test");
 
-        Assertions.assertEquals(3, config.getDoubleList("test").size());
+        Assertions.assertEquals(3, actual.size());
 
         for (Object object : actual) {
             Assertions.assertEquals(Double.class, object.getClass());
@@ -281,7 +281,7 @@ public class AbstractConfigurationTest {
 
         var actual = config.getFloatList("test");
 
-        Assertions.assertEquals(4, config.getFloatList("test").size());
+        Assertions.assertEquals(4, actual.size());
 
         for (Object object : actual) {
             Assertions.assertEquals(Float.class, object.getClass());
@@ -302,7 +302,7 @@ public class AbstractConfigurationTest {
 
         var actual = config.getIntegerList("test");
 
-        Assertions.assertEquals(4, config.getIntegerList("test").size());
+        Assertions.assertEquals(4, actual.size());
 
         for (Object object : actual) {
             Assertions.assertEquals(Integer.class, object.getClass());
@@ -323,7 +323,7 @@ public class AbstractConfigurationTest {
 
         var actual = config.getLongList("test");
 
-        Assertions.assertEquals(4, config.getLongList("test").size());
+        Assertions.assertEquals(4, actual.size());
 
         for (Object object : actual) {
             Assertions.assertEquals(Long.class, object.getClass());
@@ -344,7 +344,7 @@ public class AbstractConfigurationTest {
 
         var actual = config.getShortList("test");
 
-        Assertions.assertEquals(4, config.getShortList("test").size());
+        Assertions.assertEquals(4, actual.size());
 
         for (Object object : actual) {
             Assertions.assertEquals(Short.class, object.getClass());
@@ -363,11 +363,11 @@ public class AbstractConfigurationTest {
         var config = newConfiguration();
         config.set("test-1", list);
 
-        var actual = config.getStringList("test-1");
+        var actual1 = config.getStringList("test-1");
 
-        Assertions.assertEquals(5, config.getStringList("test-1").size());
+        Assertions.assertEquals(5, actual1.size());
 
-        for (Object object : actual) {
+        for (Object object : actual1) {
             Assertions.assertEquals(String.class, object.getClass());
         }
 
@@ -381,7 +381,7 @@ public class AbstractConfigurationTest {
 
         var actual2 = config.getStringList("test-2");
 
-        Assertions.assertEquals(3, config.getStringList("test-2").size());
+        Assertions.assertEquals(3, actual2.size());
 
         for (Object object : actual2) {
             Assertions.assertEquals(String.class, object.getClass());

--- a/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
+++ b/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
@@ -59,6 +59,26 @@ public class AbstractConfigurationTest {
         Assertions.assertTrue(config.getBoolean("test-string", true));
     }
 
+    @Test
+    void testGettingByte() {
+        var config = newConfiguration();
+
+        config.set("test-1", 5);
+        config.set("test-2", -5);
+
+        Assertions.assertEquals(5, config.getByte("test-1"));
+        Assertions.assertEquals(-5, config.getByte("test-2"));
+
+        config.set("test-3", 300);
+        Assertions.assertNotEquals(300, config.getByte("test-3"));
+
+        config.set("test-min", Byte.MIN_VALUE);
+        config.set("test-max", Byte.MAX_VALUE);
+
+        Assertions.assertEquals(Byte.MIN_VALUE, config.getByte("test-min"));
+        Assertions.assertEquals(Byte.MAX_VALUE, config.getByte("test-max"));
+    }
+
     @Contract(" -> new")
     private static @NotNull Configuration newConfiguration() {
         return MappedConfiguration.create();

--- a/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
+++ b/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
@@ -209,6 +209,27 @@ public class AbstractConfigurationTest {
         Assertions.assertEquals("100", config.getString("empty", "100"));
     }
 
+    @Test
+    void testGettingBooleanTest() {
+        var list = List.of(new Object(), true, false, Boolean.TRUE, Boolean.FALSE, 100, "test");
+
+        var config = newConfiguration();
+        config.set("test", list);
+
+        var actual = config.getBooleanList("test");
+
+        Assertions.assertEquals(4, config.getBooleanList("test").size());
+
+        for (Object object : actual) {
+            Assertions.assertEquals(Boolean.class, object.getClass());
+        }
+
+        Assertions.assertSame(Collections.emptyList(), config.getBooleanList("empty"));
+
+        var def = List.of(true, false, true, false);
+        Assertions.assertSame(def, config.getBooleanList("empty", def));
+    }
+
     @SuppressWarnings("ConstantConditions")
     @Test
     void testIllegalArguments() {

--- a/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
+++ b/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
@@ -293,6 +293,28 @@ public class AbstractConfigurationTest {
         Assertions.assertSame(def, config.getFloatList("empty", def));
     }
 
+    @Test
+    void testGettingIntegerList() {
+        var list = List.of(new Object(), 5, -5, Long.MAX_VALUE, 5.5, true, "test");
+
+        var config = newConfiguration();
+        config.set("test", list);
+
+        var actual = config.getIntegerList("test");
+
+        Assertions.assertEquals(4, config.getIntegerList("test").size());
+
+        for (Object object : actual) {
+            Assertions.assertEquals(Integer.class, object.getClass());
+        }
+
+        Assertions.assertSame(Collections.emptyList(), config.getIntegerList("empty"));
+
+        var def = List.of(5, -5);
+        Assertions.assertSame(def, config.getIntegerList("empty", def));
+    }
+
+
     @SuppressWarnings("ConstantConditions")
     @Test
     void testIllegalArguments() {

--- a/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
+++ b/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 public class AbstractConfigurationTest {
 
     @Test
-    void testGettingDefaultValue() {
+    void testDefaultValue() {
         var config = newConfiguration();
 
         var def = new Object();
@@ -39,7 +39,7 @@ public class AbstractConfigurationTest {
     }
 
     @Test
-    void testGettingList() {
+    void testList() {
         var config = newConfiguration();
 
         var list = new ArrayList<>();
@@ -50,7 +50,7 @@ public class AbstractConfigurationTest {
     }
 
     @Test
-    void testGettingBoolean() {
+    void testBoolean() {
         var config = newConfiguration();
 
         config.set("test", true);
@@ -62,7 +62,7 @@ public class AbstractConfigurationTest {
     }
 
     @Test
-    void testGettingByte() {
+    void testByte() {
         var config = newConfiguration();
 
         config.set("test-1", 5);
@@ -85,7 +85,7 @@ public class AbstractConfigurationTest {
     }
 
     @Test
-    void testGettingDouble() {
+    void testDouble() {
         var config = newConfiguration();
 
         config.set("test-1", 5);
@@ -105,7 +105,7 @@ public class AbstractConfigurationTest {
     }
 
     @Test
-    void testGettingFloat() {
+    void testFloat() {
         var config = newConfiguration();
 
         config.set("test-1", 5);
@@ -128,7 +128,7 @@ public class AbstractConfigurationTest {
     }
 
     @Test
-    void testGettingInteger() {
+    void testInteger() {
         var config = newConfiguration();
 
         config.set("test-1", 5);
@@ -151,7 +151,7 @@ public class AbstractConfigurationTest {
     }
 
     @Test
-    void testGettingLong() {
+    void testLong() {
         var config = newConfiguration();
 
         config.set("test-1", 5);
@@ -174,7 +174,7 @@ public class AbstractConfigurationTest {
     }
 
     @Test
-    void testGettingShort() {
+    void testShort() {
         var config = newConfiguration();
 
         config.set("test-1", 5);
@@ -197,7 +197,7 @@ public class AbstractConfigurationTest {
     }
 
     @Test
-    void testGettingString() {
+    void testString() {
         var config = newConfiguration();
 
         config.set("test-1", "test");
@@ -211,7 +211,7 @@ public class AbstractConfigurationTest {
     }
 
     @Test
-    void testGettingBooleanTest() {
+    void testBooleanTest() {
         var list = List.of(new Object(), true, false, Boolean.TRUE, Boolean.FALSE, 100, "test");
 
         var config = newConfiguration();
@@ -232,7 +232,7 @@ public class AbstractConfigurationTest {
     }
 
     @Test
-    void testGettingByteList() {
+    void testByteList() {
         var list = List.of(new Object(), 5, -5, 300, true, "test");
 
         var config = newConfiguration();
@@ -253,7 +253,7 @@ public class AbstractConfigurationTest {
     }
 
     @Test
-    void testGettingDoubleList() {
+    void testDoubleList() {
         var list = List.of(new Object(), 5.5, -5.5, 300, true, "test");
 
         var config = newConfiguration();
@@ -274,7 +274,7 @@ public class AbstractConfigurationTest {
     }
 
     @Test
-    void testGettingFloatList() {
+    void testFloatList() {
         var list = List.of(new Object(), 5.5, -5.5, 300, true, "test");
 
         var config = newConfiguration();
@@ -295,7 +295,7 @@ public class AbstractConfigurationTest {
     }
 
     @Test
-    void testGettingIntegerList() {
+    void testIntegerList() {
         var list = List.of(new Object(), 5, -5, Long.MAX_VALUE, 5.5, true, "test");
 
         var config = newConfiguration();
@@ -316,7 +316,7 @@ public class AbstractConfigurationTest {
     }
 
     @Test
-    void testGettingLongList() {
+    void testLongList() {
         var list = List.of(new Object(), 5, -5, Long.MAX_VALUE, 5.5, true, "test");
 
         var config = newConfiguration();
@@ -337,7 +337,7 @@ public class AbstractConfigurationTest {
     }
 
     @Test
-    void testGettingShortList() {
+    void testShortList() {
         var list = List.of(new Object(), 5, -5, Long.MAX_VALUE, 5.5, true, "test");
 
         var config = newConfiguration();
@@ -358,7 +358,7 @@ public class AbstractConfigurationTest {
     }
 
     @Test
-    void testGettingStringList() {
+    void testStringList() {
         var list = List.of(new Object(), "test", "", 100, true);
 
         var config = newConfiguration();
@@ -423,9 +423,9 @@ public class AbstractConfigurationTest {
     void testIllegalArguments() {
         var config = newConfiguration();
 
-        Assertions.assertTrue(testThrowingForIllegalArgument(() -> config.get("test", (Object) null)));
-        Assertions.assertTrue(testThrowingForIllegalArgument(() -> config.getList(null)));
-        Assertions.assertTrue(testThrowingForIllegalArgument(() -> config.getList("test", (List<?>) null)));
+        Assertions.assertTrue(testArgument(() -> config.get("test", (Object) null)));
+        Assertions.assertTrue(testArgument(() -> config.getList(null)));
+        Assertions.assertTrue(testArgument(() -> config.getList("test", (List<?>) null)));
     }
 
     @Contract(" -> new")
@@ -433,7 +433,7 @@ public class AbstractConfigurationTest {
         return MappedConfiguration.create();
     }
 
-    private static boolean testThrowingForIllegalArgument(@NotNull Runnable runnable) {
+    private static boolean testArgument(@NotNull Runnable runnable) {
         try {
             runnable.run();
             return false;

--- a/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
+++ b/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
@@ -314,6 +314,26 @@ public class AbstractConfigurationTest {
         Assertions.assertSame(def, config.getIntegerList("empty", def));
     }
 
+    @Test
+    void testGettingLongList() {
+        var list = List.of(new Object(), 5, -5, Long.MAX_VALUE, 5.5, true, "test");
+
+        var config = newConfiguration();
+        config.set("test", list);
+
+        var actual = config.getLongList("test");
+
+        Assertions.assertEquals(4, config.getLongList("test").size());
+
+        for (Object object : actual) {
+            Assertions.assertEquals(Long.class, object.getClass());
+        }
+
+        Assertions.assertSame(Collections.emptyList(), config.getLongList("empty"));
+
+        var def = List.of(5L, -5L);
+        Assertions.assertSame(def, config.getLongList("empty", def));
+    }
 
     @SuppressWarnings("ConstantConditions")
     @Test

--- a/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
+++ b/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 
@@ -391,6 +392,30 @@ public class AbstractConfigurationTest {
 
         var def = List.of("test", "test");
         Assertions.assertSame(def, config.getStringList("empty", def));
+    }
+
+    @Test
+    void testBytes() {
+        byte[] bytes = {-3, -1, 1, 3};
+
+        var config = newConfiguration();
+        config.setBytes("test", bytes);
+
+        var actual = config.getBytes("test");
+
+        Assertions.assertEquals(4, actual.length);
+
+        for (int i = 0; i < actual.length; i++) {
+            Assertions.assertEquals(bytes[i], actual[i]);
+        }
+
+        var encoded = Base64.getEncoder().encodeToString(bytes);
+        Assertions.assertEquals(encoded, config.getString("test"));
+
+        Assertions.assertEquals(0, config.getBytes("empty").length);
+
+        config.set("invalid", "*test*");
+        Assertions.assertEquals(0, config.getBytes("invalid").length);
     }
 
     @SuppressWarnings("ConstantConditions")

--- a/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
+++ b/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
@@ -251,6 +251,27 @@ public class AbstractConfigurationTest {
         Assertions.assertSame(def, config.getByteList("empty", def));
     }
 
+    @Test
+    void testGettingDoubleList() {
+        var list = List.of(new Object(), 5.5, -5.5, 300, true, "test");
+
+        var config = newConfiguration();
+        config.set("test", list);
+
+        var actual = config.getDoubleList("test");
+
+        Assertions.assertEquals(3, config.getDoubleList("test").size());
+
+        for (Object object : actual) {
+            Assertions.assertEquals(Double.class, object.getClass());
+        }
+
+        Assertions.assertSame(Collections.emptyList(), config.getDoubleList("empty"));
+
+        var def = List.of(5.5, -5.5);
+        Assertions.assertSame(def, config.getDoubleList("empty", def));
+    }
+
     @SuppressWarnings("ConstantConditions")
     @Test
     void testIllegalArguments() {

--- a/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
+++ b/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
@@ -23,6 +23,9 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.Collections;
+
 public class AbstractConfigurationTest {
 
     @Test
@@ -31,6 +34,17 @@ public class AbstractConfigurationTest {
 
         var def = new Object();
         Assertions.assertSame(def, config.get("test", def));
+    }
+
+    @Test
+    void testGettingList() {
+        var config = newConfiguration();
+
+        var list = new ArrayList<>();
+        config.set("test-list", list);
+
+        Assertions.assertSame(list, config.getList("test-list"));
+        Assertions.assertSame(Collections.emptyList(), config.getList("test"));
     }
 
     @Contract(" -> new")

--- a/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
+++ b/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
@@ -195,6 +195,20 @@ public class AbstractConfigurationTest {
         Assertions.assertEquals(100, config.getShort("empty", (short) 100));
     }
 
+    @Test
+    void testGettingString() {
+        var config = newConfiguration();
+
+        config.set("test-1", "test");
+        Assertions.assertEquals("test", config.getString("test-1"));
+
+        config.set("test-2", 100);
+        Assertions.assertEquals("100", config.getString("test-2"));
+
+        Assertions.assertEquals("", config.getString("empty"));
+        Assertions.assertEquals("100", config.getString("empty", "100"));
+    }
+
     @SuppressWarnings("ConstantConditions")
     @Test
     void testIllegalArguments() {

--- a/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
+++ b/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
@@ -126,6 +126,29 @@ public class AbstractConfigurationTest {
         Assertions.assertEquals(100, config.getFloat("empty", 100));
     }
 
+    @Test
+    void testGettingInteger() {
+        var config = newConfiguration();
+
+        config.set("test-1", 5);
+        config.set("test-2", -5);
+
+        Assertions.assertEquals(5, config.getInteger("test-1"));
+        Assertions.assertEquals(-5, config.getInteger("test-2"));
+
+        config.set("test-3", Long.MAX_VALUE);
+        Assertions.assertNotEquals(Long.MAX_VALUE, config.getInteger("test-3"));
+
+        config.set("test-min", Integer.MIN_VALUE);
+        config.set("test-max", Integer.MAX_VALUE);
+
+        Assertions.assertEquals(Integer.MIN_VALUE, config.getInteger("test-min"));
+        Assertions.assertEquals(Integer.MAX_VALUE, config.getInteger("test-max"));
+
+        Assertions.assertEquals(0, config.getInteger("empty"));
+        Assertions.assertEquals(100, config.getInteger("empty", 100));
+    }
+
     @SuppressWarnings("ConstantConditions")
     @Test
     void testIllegalArguments() {

--- a/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
+++ b/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
@@ -108,13 +108,22 @@ public class AbstractConfigurationTest {
     void testIllegalArguments() {
         var config = newConfiguration();
 
-        Assertions.assertThrows(IllegalArgumentException.class, () -> config.get("test", (Object) null));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> config.getList(null));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> config.getList("test", (List<?>) null));
+        Assertions.assertTrue(testThrowingForIllegalArgument(() -> config.get("test", (Object) null)));
+        Assertions.assertTrue(testThrowingForIllegalArgument(() -> config.getList(null)));
+        Assertions.assertTrue(testThrowingForIllegalArgument(() -> config.getList("test", (List<?>) null)));
     }
 
     @Contract(" -> new")
     private static @NotNull Configuration newConfiguration() {
         return MappedConfiguration.create();
+    }
+
+    private static boolean testThrowingForIllegalArgument(@NotNull Runnable runnable) {
+        try {
+            runnable.run();
+            return false;
+        } catch (Throwable throwable) {
+            return throwable instanceof NullPointerException || throwable instanceof IllegalArgumentException;
+        }
     }
 }

--- a/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
+++ b/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
@@ -272,6 +272,27 @@ public class AbstractConfigurationTest {
         Assertions.assertSame(def, config.getDoubleList("empty", def));
     }
 
+    @Test
+    void testGettingFloatList() {
+        var list = List.of(new Object(), 5.5, -5.5, 300, true, "test");
+
+        var config = newConfiguration();
+        config.set("test", list);
+
+        var actual = config.getFloatList("test");
+
+        Assertions.assertEquals(4, config.getFloatList("test").size());
+
+        for (Object object : actual) {
+            Assertions.assertEquals(Float.class, object.getClass());
+        }
+
+        Assertions.assertSame(Collections.emptyList(), config.getFloatList("empty"));
+
+        var def = List.of(5.5f, -5.5f);
+        Assertions.assertSame(def, config.getFloatList("empty", def));
+    }
+
     @SuppressWarnings("ConstantConditions")
     @Test
     void testIllegalArguments() {

--- a/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
+++ b/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
@@ -1,0 +1,21 @@
+/*
+ *     Copyright 2021 Siroshun09
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+
+package com.github.siroshun09.configapi.api.test;
+
+public class AbstractConfigurationTest {
+
+}

--- a/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
+++ b/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
@@ -78,6 +78,9 @@ public class AbstractConfigurationTest {
 
         Assertions.assertEquals(Byte.MIN_VALUE, config.getByte("test-min"));
         Assertions.assertEquals(Byte.MAX_VALUE, config.getByte("test-max"));
+
+        Assertions.assertEquals(0, config.getByte("empty"));
+        Assertions.assertEquals(100, config.getByte("empty", (byte) 100));
     }
 
     @Test

--- a/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
+++ b/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 public class AbstractConfigurationTest {
 
@@ -77,6 +78,16 @@ public class AbstractConfigurationTest {
 
         Assertions.assertEquals(Byte.MIN_VALUE, config.getByte("test-min"));
         Assertions.assertEquals(Byte.MAX_VALUE, config.getByte("test-max"));
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    @Test
+    void testIllegalArguments() {
+        var config = newConfiguration();
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> config.get("test", (Object) null));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> config.getList(null));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> config.getList("test", (List<?>) null));
     }
 
     @Contract(" -> new")

--- a/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
+++ b/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
@@ -16,6 +16,26 @@
 
 package com.github.siroshun09.configapi.api.test;
 
+import com.github.siroshun09.configapi.api.Configuration;
+import com.github.siroshun09.configapi.api.MappedConfiguration;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 public class AbstractConfigurationTest {
+
+    @Test
+    void testGettingDefaultValue() {
+        var config = newConfiguration();
+
+        var def = new Object();
+        Assertions.assertSame(def, config.get("test", def));
+    }
+
+    @Contract(" -> new")
+    private static @NotNull Configuration newConfiguration() {
+        return MappedConfiguration.create();
+    }
 
 }

--- a/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
+++ b/api/src/test/java/com/github/siroshun09/configapi/api/test/AbstractConfigurationTest.java
@@ -172,6 +172,29 @@ public class AbstractConfigurationTest {
         Assertions.assertEquals(100, config.getLong("empty", 100));
     }
 
+    @Test
+    void testGettingShort() {
+        var config = newConfiguration();
+
+        config.set("test-1", 5);
+        config.set("test-2", -5);
+
+        Assertions.assertEquals(5, config.getShort("test-1"));
+        Assertions.assertEquals(-5, config.getShort("test-2"));
+
+        config.set("test-3", Double.MAX_VALUE);
+        Assertions.assertNotEquals(Double.MAX_VALUE, config.getShort("test-3"));
+
+        config.set("test-min", Short.MIN_VALUE);
+        config.set("test-max", Short.MAX_VALUE);
+
+        Assertions.assertEquals(Short.MIN_VALUE, config.getShort("test-min"));
+        Assertions.assertEquals(Short.MAX_VALUE, config.getShort("test-max"));
+
+        Assertions.assertEquals(0, config.getShort("empty"));
+        Assertions.assertEquals(100, config.getShort("empty", (short) 100));
+    }
+
     @SuppressWarnings("ConstantConditions")
     @Test
     void testIllegalArguments() {

--- a/api/src/test/java/com/github/siroshun09/configapi/api/test/MappedConfigurationTest.java
+++ b/api/src/test/java/com/github/siroshun09/configapi/api/test/MappedConfigurationTest.java
@@ -80,11 +80,6 @@ class MappedConfigurationTest {
             }
 
             @Override
-            public @NotNull @Unmodifiable Set<String> getPaths() {
-                return Set.of("key", "map");
-            }
-
-            @Override
             public @NotNull @Unmodifiable List<String> getKeyList() {
                 return List.of("key", "map");
             }

--- a/api/src/test/java/com/github/siroshun09/configapi/api/test/util/ResourceUtilsTest.java
+++ b/api/src/test/java/com/github/siroshun09/configapi/api/test/util/ResourceUtilsTest.java
@@ -46,7 +46,10 @@ public class ResourceUtilsTest {
         ResourceUtils.copyFromJar(JAR_PATH, "test.txt", TEXT_PATH);
         Assertions.assertTrue(Files.exists(TEXT_PATH));
 
-        Files.delete(JAR_PATH);
-        Files.delete(TEXT_PATH);
+        try {
+            Files.delete(JAR_PATH);
+            Files.delete(TEXT_PATH);
+        } catch (Exception ignored) {
+        }
     }
 }

--- a/api/src/test/java/com/github/siroshun09/configapi/api/test/util/ResourceUtilsTest.java
+++ b/api/src/test/java/com/github/siroshun09/configapi/api/test/util/ResourceUtilsTest.java
@@ -30,29 +30,23 @@ public class ResourceUtilsTest {
     private static final Path TEXT_PATH = Path.of("test.txt");
 
     @Test
-    void testCopyingFromClassLoader() throws IOException {
+    void testResourceCopy() throws IOException {
         if (Files.exists(JAR_PATH)) {
             Files.delete(JAR_PATH);
+        }
+
+        if (Files.exists(TEXT_PATH)) {
+            Files.delete(TEXT_PATH);
         }
 
         ResourceUtils.copyFromClassLoader(getClass().getClassLoader(), "example.jar", JAR_PATH);
 
         Assertions.assertTrue(Files.exists(JAR_PATH));
 
-        Files.delete(JAR_PATH);
-    }
-
-    @Test
-    void testCopyingFromJar() throws IOException {
-        if (Files.exists(TEXT_PATH)) {
-            Files.delete(TEXT_PATH);
-        }
-
-        ResourceUtils.copyFromClassLoaderIfNotExists(getClass().getClassLoader(), "example.jar", JAR_PATH);
-
         ResourceUtils.copyFromJar(JAR_PATH, "test.txt", TEXT_PATH);
         Assertions.assertTrue(Files.exists(TEXT_PATH));
 
+        Files.delete(JAR_PATH);
         Files.delete(TEXT_PATH);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>com.github.siroshun09.configapi</groupId>
     <artifactId>parent</artifactId>
-    <version>4.4.0-SNAPSHOT</version>
+    <version>4.4.0</version>
     <packaging>pom</packaging>
 
     <name>ConfigAPI</name>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>com.github.siroshun09.configapi</groupId>
     <artifactId>parent</artifactId>
-    <version>4.3.1</version>
+    <version>4.4.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>ConfigAPI</name>

--- a/yaml/pom.xml
+++ b/yaml/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.github.siroshun09.configapi</groupId>
         <artifactId>parent</artifactId>
-        <version>4.3.1</version>
+        <version>4.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.github.siroshun09.configapi</groupId>
             <artifactId>configapi</artifactId>
-            <version>4.3.1</version>
+            <version>4.4.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/yaml/pom.xml
+++ b/yaml/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.github.siroshun09.configapi</groupId>
         <artifactId>parent</artifactId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>4.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.github.siroshun09.configapi</groupId>
             <artifactId>configapi</artifactId>
-            <version>4.4.0-SNAPSHOT</version>
+            <version>4.4.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/yaml/src/main/java/com/github/siroshun09/configapi/yaml/YamlConfiguration.java
+++ b/yaml/src/main/java/com/github/siroshun09/configapi/yaml/YamlConfiguration.java
@@ -134,11 +134,6 @@ public class YamlConfiguration extends AbstractFileConfiguration {
     }
 
     @Override
-    public @NotNull @Unmodifiable Set<String> getPaths() {
-        return config != null ? config.getPaths() : Collections.emptySet();
-    }
-
-    @Override
     public @NotNull @Unmodifiable List<String> getKeyList() {
         return config != null ? config.getKeyList() : Collections.emptyList();
     }


### PR DESCRIPTION
## Changes

- Remove `Configuration#getPaths`
- Add more null checks
- Improve Javadocs

## Tests

- Add tests for `AbstractConfiguration`
- Improve some tests

## CI

- Java CI (`maven.yml`) is now building on Java 11 and 16
- Deploy Javadoc to GitHub Pages (Maven) (`update-javadoc.yml`) is now building on Java 16

